### PR TITLE
Parse and write out comm_use_subset as tsv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,12 @@ update:
 	conda activate db_covid19
 	conda update --file environment.yml
 
-## data            : downloads all the source data for the repository
-.PHONY: data
-data:
+## data_kaggle     : downloads he kaggle source data for the repository
+.PHONY: data_kaggle
+data_kaggle:
 	kaggle datasets download allen-institute-for-ai/CORD-19-research-challenge -p ./data/db/original/kaggle --unzip
+
+## data_kaggle     : downloads he kaggle source data for the repository
+.PHONY: data_kgl_text
+data_kgl_text:
+	python ./analysis/db/dan/load_data.py

--- a/analysis/db/dan/load_data.py
+++ b/analysis/db/dan/load_data.py
@@ -1,0 +1,54 @@
+import pathlib as pl
+import json
+
+import pandas as pd
+from tqdm import tqdm
+
+from pyprojroot import here
+
+def extract_paper_component(paper_json, section_key, text_key="text", line_delim="\n"):
+    section_text = map(lambda x: x[text_key], paper_json[section_key])
+    text = line_delim.join(section_text)
+    return(text)
+
+def extract_body_text(paper_json, **kwargs):
+    paper_text = extract_paper_component(paper_json, **kwargs)
+    return(paper_text)
+
+def extract_abstract_text(paper_json, **kwargs):
+    abstract_text = extract_paper_component(paper_json, **kwargs)
+    return(abstract_text)
+
+def extract_paper_data(json_pth):
+    with open(json_pth) as f:
+        data = json.load(f)
+
+    paper_text = extract_body_text(data, section_key="body_text", text_key="text")
+    abstract_text = extract_abstract_text(data, section_key="abstract", text_key="text")
+    pid = data['paper_id']
+    title = data['metadata']['title']
+    num_authors = len(data['metadata']['authors'])
+
+    paper_data = pd.DataFrame(
+        data = [
+            [pid, num_authors, title, abstract_text, paper_text]
+        ],
+        columns = ["pid", "num_authors", "title", "abstract", "text"]
+    )
+    return(paper_data)
+
+p = here()
+
+fs = here("./data/db/original/kaggle/comm_use_subset/comm_use_subset").iterdir()
+
+# fs = list(fs)
+fs = list(fs)
+
+papers = pd.concat(
+    [extract_paper_data(jsn) for jsn in tqdm(fs)]
+)
+
+papers.info()
+
+pl.Path(here("./data/db/final/kaggle/paper_text/")).mkdir(parents=True, exist_ok=True)
+papers.to_csv(here("./data/db/final/kaggle/paper_text/comm_use_subset.tsv"), sep="\t", header=True, index=False)

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - beautifulsoup4=4.8.2
   - kaggle=1.5.6
+  - pandas=1.0.3
   - pip=20.0.2
   - python=3.8.2
   - pyprojroot=0.2.0


### PR DESCRIPTION
takes all the json files in the `comm_use_subset` kaggle dataset and extracts:

- paper id
- number of authors
- title
- abstract text
- paper text

and writes it to a `tsv` file